### PR TITLE
Adiciona dependências concretas ao projeto e corrige o Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yum -y upgrade python-setuptools
 
 COPY . /app
 
-RUN pip install --upgrade pip
+RUN pip install -r /app/requirements.txt
 RUN chmod -R 755 /app/*
 
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+articlemetaapi==1.6.15
+backports.ssl-match-hostname==3.4.0.2
+chardet==2.2.1
+iniparse==0.4
+kitchen==1.1.1
+ply==3.9
+pycurl==7.19.0
+pygobject==3.22.0
+pygpgme==0.3
+pyliblzma==0.5.3
+pymongo==3.4.0
+pyxattr==0.5.1
+requests==2.11.1
+thriftpy==0.3.1
+urlgrabber==3.10
+xylose==1.16.5
+yum-metadata-parser==1.1.4


### PR DESCRIPTION
Este commit adiciona o arquivo de dependências do projeto, foram
utilizadas a lista de dependências da última imagem docker hospedada
no Docker Hub.

Foi necessário remover a linha que atualiza a versão do `pip` porque
o python 2 foi descontinuado e o build acabava falhando.